### PR TITLE
chore: Catalog in Backstage [SRE-1101]

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -3,12 +3,10 @@ kind: Component
 metadata:
   # Name of the project 
   name: ory-docs
-  description: A few scripts to administer git repos and permissions
+  description: Documentation for all ORY products
   # Specifies the directory of the docs
   annotations:
     backstage.io/techdocs-ref: dir:.
-
-  labels:
 
   links:
     # Slack channel to write in for communicating with the resposible team.

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,35 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  # Name of the project 
+  name: ory-docs
+  description: A few scripts to administer git repos and permissions
+  # Specifies the directory of the docs
+  annotations:
+    backstage.io/techdocs-ref: dir:.
+
+  labels:
+
+  links:
+    # Slack channel to write in for communicating with the resposible team.
+  - title: Team Slack Channel
+    url: <url> # TODO
+    type: Slack
+    icon: chat
+    # Page in notion documenting the purpose and function of the service 
+  - title: Notion
+    url: <url> # TODO
+    type: Notion
+    icon: docs
+    # Link to the most relevant grafana dashboard, i recommend a "4 golden signals" dashboard
+  - url: <url> # TODO
+    title: Grafana
+    icon: dashboard
+    type: metrics-dashboard
+
+# The spec defines who becomes the owner of the system in backstage
+spec:
+  type: <type> # TODO
+  lifecycle: <production|experimental> # TODO
+  owner: <squad> # TODO
+  system: <system> # TODO


### PR DESCRIPTION
# Description

## What?

Add catalog-info.yaml to repo to catalog in Backstage.

This needs to be updated and merged by Apr 1 2025.

Please input values for all placeholders in `catalog-info.yaml`:
 - [ ] Slack url updated
 - [ ] Notion url updated
 - [ ] Grafana url updated
 - [ ] Type updated
 - [ ] Lifecycle updated
 - [ ] Owner updated (set to your squad in Monta)
 - [ ] System updated (set to your division in Monta)

See possible values for type, owner and system in https://backstage.monta.app

## Why?

We are required to keep a catalog of our services in Backstage. This requires `catalog-info.yaml` to be in your repo, which is introduced in this PR.